### PR TITLE
S3C-10122: Switch deprecated reviewers to CODEOWNERS for dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @scality/object

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "scality/object"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    reviewers:
-      - "scality/object"


### PR DESCRIPTION
Issue: S3C-10122

Switch deprecated reviewers to CODEOWNERS for dependabot
[Reference](https://github.com/scality/devdocs/discussions/718)